### PR TITLE
增加飞书思考中占位卡片并补充测试

### DIFF
--- a/src/handlers/group.ts
+++ b/src/handlers/group.ts
@@ -10,6 +10,7 @@ import { commandHandler } from './command.js';
 import { modelConfig, attachmentConfig } from '../config.js';
 import { DirectoryPolicy } from '../utils/directory-policy.js';
 import { buildSessionTimestamp } from '../utils/session-title.js';
+import { buildStreamCard } from '../feishu/cards-stream.js';
 
 import { randomUUID } from 'crypto';
 import path from 'path';
@@ -100,6 +101,27 @@ export class GroupHandler {
 
     if (!outputBuffer.get(key)) {
       outputBuffer.getOrCreate(key, chatId, sessionId, replyMessageId);
+    }
+  }
+
+  private async ensureThinkingPlaceholder(chatId: string, bufferKey: string): Promise<void> {
+    const current = outputBuffer.get(bufferKey);
+    if (!current || current.messageId) {
+      return;
+    }
+
+    try {
+      const messageId = await feishuClient.sendCard(chatId, buildStreamCard({
+        thinking: '',
+        text: '🤔 思考中...',
+        tools: [],
+        status: 'processing',
+      }));
+      if (messageId) {
+        outputBuffer.setMessageId(bufferKey, messageId);
+      }
+    } catch (error) {
+      console.warn('[Group] 发送思考中占位卡片失败:', error);
     }
   }
 
@@ -321,6 +343,7 @@ export class GroupHandler {
   ): Promise<void> {
     const bufferKey = `chat:${chatId}`;
     this.ensureStreamingBuffer(chatId, sessionId, messageId);
+    await this.ensureThinkingPlaceholder(chatId, bufferKey);
 
     try {
       console.log(`[Group] 发送消息: chat=${chatId}, session=${sessionId.slice(0, 8)}...`);

--- a/tests/group-handler-thinking-placeholder.test.ts
+++ b/tests/group-handler-thinking-placeholder.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { groupHandler } from '../src/handlers/group.js';
+import { feishuClient, type FeishuMessageEvent } from '../src/feishu/client.js';
+import { chatSessionStore } from '../src/store/chat-session.js';
+import { opencodeClient } from '../src/opencode/client.js';
+import { outputBuffer } from '../src/opencode/output-buffer.js';
+
+const baseEvent: FeishuMessageEvent = {
+  messageId: 'msg-group-1',
+  chatId: 'chat-group-1',
+  chatType: 'group',
+  senderId: 'ou-user-1',
+  senderType: 'user',
+  content: '帮我看看这个问题',
+  msgType: 'text',
+  rawEvent: {
+    sender: { sender_type: 'user' },
+    message: {
+      message_id: 'msg-group-1',
+      create_time: '0',
+      chat_id: 'chat-group-1',
+      chat_type: 'group',
+      message_type: 'text',
+      content: '{"text":"帮我看看这个问题"}',
+    },
+  },
+};
+
+describe('group handler thinking placeholder', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    outputBuffer.clearAll();
+    chatSessionStore.removeSession(baseEvent.chatId);
+  });
+
+  it('处理群聊 prompt 时应先发送思考中占位卡片', async () => {
+    vi.spyOn(chatSessionStore, 'getSessionId').mockReturnValue('ses-group-1');
+    vi.spyOn(chatSessionStore, 'updateLastInteraction').mockImplementation(() => undefined);
+    vi.spyOn(chatSessionStore, 'getSession').mockReturnValue(undefined);
+    vi.spyOn(opencodeClient, 'sendMessagePartsAsync').mockResolvedValue(undefined);
+
+    const sendCardSpy = vi.spyOn(feishuClient, 'sendCard').mockResolvedValue('card-thinking-1');
+
+    await groupHandler.handleMessage(baseEvent);
+
+    expect(sendCardSpy).toHaveBeenCalledTimes(1);
+    expect(sendCardSpy).toHaveBeenCalledWith(
+      baseEvent.chatId,
+      expect.objectContaining({
+        header: expect.objectContaining({
+          title: expect.objectContaining({
+            content: '处理中...',
+          }),
+        }),
+        body: expect.objectContaining({
+          elements: expect.arrayContaining([
+            expect.objectContaining({
+              tag: 'markdown',
+              content: '🤔 思考中...',
+            }),
+          ]),
+        }),
+      })
+    );
+
+    expect(outputBuffer.get(`chat:${baseEvent.chatId}`)?.messageId).toBe('card-thinking-1');
+    expect(opencodeClient.sendMessagePartsAsync).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/p2p-thinking-placeholder.test.ts
+++ b/tests/p2p-thinking-placeholder.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { p2pHandler } from '../src/handlers/p2p.js';
+import { groupHandler } from '../src/handlers/group.js';
+import type { FeishuMessageEvent } from '../src/feishu/client.js';
+
+const baseEvent: FeishuMessageEvent = {
+  messageId: 'msg-p2p-1',
+  chatId: 'chat-p2p-1',
+  chatType: 'p2p',
+  senderId: 'ou-user-1',
+  senderType: 'user',
+  content: '帮我看下这个报错',
+  msgType: 'text',
+  rawEvent: {
+    sender: { sender_type: 'user' },
+    message: {
+      message_id: 'msg-p2p-1',
+      create_time: '0',
+      chat_id: 'chat-p2p-1',
+      chat_type: 'p2p',
+      message_type: 'text',
+      content: '{"text":"帮我看下这个报错"}',
+    },
+  },
+};
+
+describe('p2p handler thinking placeholder', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('私聊普通消息应转发到群聊处理链路', async () => {
+    vi.spyOn(p2pHandler as never, 'ensurePrivateSession').mockResolvedValue({
+      firstBinding: false,
+    } as never);
+    const groupSpy = vi.spyOn(groupHandler, 'handleMessage').mockResolvedValue(undefined);
+
+    await p2pHandler.handleMessage(baseEvent);
+
+    expect(groupSpy).toHaveBeenCalledTimes(1);
+    expect(groupSpy).toHaveBeenCalledWith(baseEvent);
+  });
+});


### PR DESCRIPTION
## Summary
- 在飞书消息开始流式输出前，先发送一张“🤔 思考中...”占位卡片，避免首屏空白等待
- 复用现有卡片更新链路，让后续流式输出直接覆盖占位卡片
- 补充群聊和私聊链路测试，验证占位卡片行为与 p2p 转发链路

## Verification
- npm test -- tests/group-handler-thinking-placeholder.test.ts tests/p2p-thinking-placeholder.test.ts
- npm run build