### PR TITLE
fix: dedup, idempotent start, and ensurePrivateSession mutex for Feishu WebSocket

### DIFF
--- a/src/feishu/client.ts
+++ b/src/feishu/client.ts
@@ -42,6 +42,10 @@ class FeishuClient extends EventEmitter {
   // 机器人自身信息
   private botOpenId: string | null = null;
 
+  // message_id 去重缓存：WebSocket 可能重复投递同一条消息
+  private _recentMessageIds = new Map<string, number>();
+  private readonly _RECENT_MESSAGE_TTL_MS = 30000;
+
   constructor() {
     super();
     this.client = new lark.Client({
@@ -153,6 +157,10 @@ class FeishuClient extends EventEmitter {
 
   // 启动长连接
   async start(): Promise<void> {
+    if (this.connectionState === 'connected' || this.connectionState === 'connecting') {
+      console.log('[飞书] 长连接已连接/连接中，忽略重复调用');
+      return;
+    }
     console.log('[飞书] 正在启动长连接...');
     this.connectionState = 'connecting';
 
@@ -241,6 +249,26 @@ class FeishuClient extends EventEmitter {
       // 忽略机器人自己发的消息
       if (sender.sender_type === 'bot') {
         return;
+      }
+
+      // 消息去重：飞书 WebSocket 可能重复投递同一条消息
+      const msgId = message.message_id;
+      if (msgId) {
+        const now = Date.now();
+        const recent = this._recentMessageIds.get(msgId);
+        if (recent !== undefined && now - recent < this._RECENT_MESSAGE_TTL_MS) {
+          console.log(`[飞书] 忽略重复消息: messageId=${msgId.slice(0, 16)}...`);
+          return;
+        }
+        this._recentMessageIds.set(msgId, now);
+        // 惰性清理：每收到 500 条消息后扫一遍过期记录
+        if (this._recentMessageIds.size >= 500) {
+          for (const [id, ts] of this._recentMessageIds) {
+            if (now - ts >= this._RECENT_MESSAGE_TTL_MS) {
+              this._recentMessageIds.delete(id);
+            }
+          }
+        }
       }
 
       const msgType = message.message_type;

--- a/src/handlers/p2p.ts
+++ b/src/handlers/p2p.ts
@@ -25,6 +25,9 @@ export class P2PHandler {
   private createChatDirectoryInputMap: Map<string, { value: string; expiresAt: number }> = new Map();
   private createChatNameInputMap: Map<string, { value: string; expiresAt: number }> = new Map();
 
+  // per-chatId 互斥锁，防 ensurePrivateSession TOCTOU 竞态
+  private _ensureSessionLocks = new Map<string, Promise<EnsurePrivateSessionResult | null>>();
+
   private async safeReply(
     messageId: string | undefined,
     chatId: string | undefined,
@@ -470,6 +473,23 @@ export class P2PHandler {
   }
 
   private async ensurePrivateSession(chatId: string, senderId: string): Promise<EnsurePrivateSessionResult | null> {
+    // per-chatId 互斥锁：等第一个完成，防止并发的 handleMessage 都走到创建 session
+    const pending = this._ensureSessionLocks.get(chatId);
+    if (pending) {
+      return await pending;
+    }
+    const promise = this._ensurePrivateSessionImpl(chatId, senderId);
+    this._ensureSessionLocks.set(chatId, promise);
+    try {
+      return await promise;
+    } finally {
+      if (this._ensureSessionLocks.get(chatId) === promise) {
+        this._ensureSessionLocks.delete(chatId);
+      }
+    }
+  }
+
+  private async _ensurePrivateSessionImpl(chatId: string, senderId: string): Promise<EnsurePrivateSessionResult | null> {
     const current = chatSessionStore.getSession(chatId);
     if (current?.sessionId) {
       const missing = await this.isSessionMissingInOpenCode(current.sessionId);


### PR DESCRIPTION

## Problem

When sending a message on Feishu/Lark, the bridge replies twice and creates duplicate OpenCode sessions. Root cause: Feishu WebSocket may deliver the same `im.message.receive_v1` event **twice**.

Three concurrency gaps exist:

1. **No message dedup** — `handleMessage()` processes every event without checking `message_id`
2. **No idempotent start** — `start()` can be called multiple times, creating multiple `WSClient` connections
3. **TOCTOU race in ensurePrivateSession** — Two concurrent `handleMessage` calls both read `chatSessionStore.getSession()` before either writes, then both create a new session

## Changes

### 1. `src/feishu/client.ts` — message_id dedup cache
- Add a `Map<string, number>` tracking recent `message_id` values with 30s TTL
- In `handleMessage()`, skip if same `message_id` seen within TTL
- Lazy cleanup every 500 entries to prevent memory leak

### 2. `src/feishu/client.ts` — idempotent start()
- Guard `start()` with early return if `connectionState` is already `'connected'` or `'connecting'`

### 3. `src/handlers/p2p.ts` — ensurePrivateSession mutex
- Add `_ensureSessionLocks` (per-chatId promise lock)
- Rename original implementation to `_ensurePrivateSessionImpl`
- New `ensurePrivateSession` wrapper: if a lock exists for `chatId`, await the pending promise instead of entering the critical section

## Testing
- The compiled JS files have been running in production with these fixes applied
- Verified no regressions in session creation and message flow
